### PR TITLE
Read swagger servlet configuration items from properties

### DIFF
--- a/features/vertx-jersey-swagger/src/main/java/com/englishtown/vertx/jersey/features/swagger/SwaggerFeature.java
+++ b/features/vertx-jersey-swagger/src/main/java/com/englishtown/vertx/jersey/features/swagger/SwaggerFeature.java
@@ -3,7 +3,6 @@ package com.englishtown.vertx.jersey.features.swagger;
 import com.englishtown.vertx.jersey.features.swagger.internal.SwaggerCorsFilter;
 import com.englishtown.vertx.jersey.features.swagger.internal.SwaggerFeatureBinder;
 import io.swagger.config.ScannerFactory;
-import io.swagger.jaxrs.config.BeanConfig;
 import io.swagger.jaxrs.config.DefaultJaxrsScanner;
 import io.swagger.jaxrs.listing.ApiListingResource;
 import io.swagger.jaxrs.listing.SwaggerSerializers;

--- a/features/vertx-jersey-swagger/src/test/java/com/englishtown/vertx/jersey/features/swagger/internal/SwaggerServletConfigTest.java
+++ b/features/vertx-jersey-swagger/src/test/java/com/englishtown/vertx/jersey/features/swagger/internal/SwaggerServletConfigTest.java
@@ -1,0 +1,95 @@
+package com.englishtown.vertx.jersey.features.swagger.internal;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import javax.servlet.ServletContext;
+import javax.ws.rs.core.Configuration;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
+
+import static io.swagger.jaxrs.config.SwaggerContextService.*;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link SwaggerServletConfig}
+ */
+public class SwaggerServletConfigTest {
+
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    private final String configId = "configId";
+    private final String scannerId = "scannerId";
+    private final String contextId = "contextId";
+
+    private SwaggerServletConfig servletConfig;
+    private Map<String, Object> properties = new HashMap<>();
+
+    @Mock
+    private ServletContext context;
+    @Mock
+    private Configuration configuration;
+
+    @Before
+    public void setUp() throws Exception {
+        properties.put(CONFIG_ID_KEY, configId);
+        properties.put(SCANNER_ID_KEY, scannerId);
+        properties.put(CONTEXT_ID_KEY, contextId);
+
+        when(context.getContextPath()).thenReturn("basePath");
+        when(configuration.getProperties()).thenReturn(properties);
+    }
+
+    @Test
+    public void testInitParamsCreation() throws Exception {
+        servletConfig = new SwaggerServletConfig(context, configuration);
+
+        assertNotNull(servletConfig);
+
+        assertEquals(configId, servletConfig.getInitParameter(CONFIG_ID_KEY));
+        assertEquals(scannerId, servletConfig.getInitParameter(SCANNER_ID_KEY));
+        assertEquals(contextId, servletConfig.getInitParameter(CONTEXT_ID_KEY));
+    }
+
+    @Test
+    public void testInitParamsCreation_nullProperty() throws Exception {
+        properties.put(CONFIG_ID_KEY, null);
+
+        servletConfig = new SwaggerServletConfig(context, configuration);
+
+        assertNotNull(servletConfig);
+
+        assertNull(servletConfig.getInitParameter(CONFIG_ID_KEY));
+    }
+
+    @Test
+    public void testInitParamsCreation_ignoredProperty() throws Exception {
+        String ignoredKey = "ignore";
+        properties.put(ignoredKey, "test-value");
+
+        servletConfig = new SwaggerServletConfig(context, configuration);
+
+        assertNotNull(servletConfig);
+
+        assertNull(servletConfig.getInitParameter(ignoredKey));
+    }
+
+    @Test
+    public void testGetInitParameterNames() throws Exception {
+        servletConfig = new SwaggerServletConfig(context, configuration);
+
+        Enumeration<String> paramNames = servletConfig.getInitParameterNames();
+        assertNotNull(paramNames);
+
+        while (paramNames.hasMoreElements()) {
+            assertTrue(properties.keySet().contains(paramNames.nextElement()));
+        }
+    }
+}

--- a/features/vertx-jersey-swagger/src/test/resources/config.json
+++ b/features/vertx-jersey-swagger/src/test/resources/config.json
@@ -1,0 +1,11 @@
+{
+    "hk2_binder": "com.englishtown.vertx.jersey.integration.IntegrationBinder",
+    "host": "0.0.0.0",
+    "port": 8080,
+    "base_path": "/rest",
+    "resources": ["com.englishtown.vertx.jersey.resources"],
+    "properties": {
+        "swagger.config.id": "test-config-id",
+        "swagger.context.id": "test-context-id"
+    }
+}


### PR DESCRIPTION
Update the SwaggerServletConfig to read the configId, contextId, and scannerId values from the Configuration properties and set the corresponding initParameters. 